### PR TITLE
Fixing missing uses in ExampleEntity

### DIFF
--- a/api/src/Entity/ExampleEntity.php
+++ b/api/src/Entity/ExampleEntity.php
@@ -8,6 +8,8 @@ use ApiPlatform\Core\Annotation\ApiResource;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\MaxDepth;
 
 


### PR DESCRIPTION
When spinning up the unchanged proto component as first test either the build or the execution will fail due to two missing uses in the example entity.
With adding these missing uses the proto component should spin up without any disturbances.